### PR TITLE
feature: support witness transactions by using riemann-tx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bitcoind_mock/conf.py

--- a/bitcoind_mock/bitcoind.py
+++ b/bitcoind_mock/bitcoind.py
@@ -13,7 +13,7 @@ from flask import Flask, request, Response, abort
 from riemann import tx
 
 from bitcoind_mock.rpc_errors import *
-import bitcoind_mock.conf as conf
+from bitcoind_mock import conf, utils
 from bitcoind_mock import transaction
 from bitcoind_mock.zmq_publisher import ZMQPublisher
 
@@ -106,7 +106,7 @@ class BitcoindMock:
        Returns:
             :obj:`tuple`: A three item tuple (block_hash, coinbase_tx, coinbase_tx_hash)
         """
-        block_hash = os.urandom(32).hex()
+        block_hash = utils.get_random_value_hex(32)
         coinbase_tx = transaction.create_dummy_transaction()
 
         return block_hash, coinbase_tx.hex(), coinbase_tx.tx_id.hex()

--- a/bitcoind_mock/transaction.py
+++ b/bitcoind_mock/transaction.py
@@ -1,152 +1,16 @@
-# Porting some functionality from https://github.com/sr-gi/bitcoin_tools with some modifications <3
-from os import urandom
+from riemann import tx
+from riemann import utils as rutils
 
-from bitcoind_mock.utils import *
+from bitcoind_mock import utils
 
 
-class TX:
-    """ Defines a class TX (transaction) that holds all the modifiable fields of a Bitcoin transaction, such as
-    version, number of inputs, reference to previous transactions, input and output scripts, value, etc.
-    """
+def create_dummy_transaction(prev_tx_id=None, prev_out_index=None):
+    if prev_tx_id is None or len(prev_tx_id) != 64:
+        prev_tx_id = utils.get_random_value_hex(32)
 
-    def __init__(self):
-        self.version = None
-        self.inputs = None
-        self.outputs = None
-        self.nLockTime = None
-        self.prev_tx_id = []
-        self.prev_out_index = []
-        self.scriptSig = []
-        self.scriptSig_len = []
-        self.nSequence = []
-        self.value = []
-        self.scriptPubKey = []
-        self.scriptPubKey_len = []
+    idx = prev_out_index if prev_out_index is not None else 0
+    prev_out_index_bytes = rutils.i2le_padded(idx, 4).hex()
 
-        self.offset = 0
-        self.hex = ""
+    dummy_hex = f"0100000001{prev_tx_id}{prev_out_index_bytes}4847304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901ffffffff0100f2052a01000000434104ae1a62fe09c5f51b13905f07f06b99a2f7159b2225f374cd378d71302fa28414e7aab37397f554a7df5f142c21c1b7303b8a0626f1baded5c72a704f7e6cd84cac00000000"
 
-    @classmethod
-    def deserialize(cls, hex_tx):
-        """ Builds a transaction object from the hexadecimal serialization format of a transaction that
-        could be obtained, for example, from a blockexplorer.
-        :param hex_tx: Hexadecimal serialized transaction.
-        :type hex_tx: hex str
-        :return: The transaction build using the provided hex serialized transaction.
-        :rtype: TX
-        """
-
-        tx = cls()
-        tx.hex = hex_tx
-
-        try:
-            tx.version = int(change_endianness(parse_element(tx, 4)), 16)
-
-            # INPUTS
-            tx.inputs = int(parse_varint(tx), 16)
-
-            for i in range(tx.inputs):
-                tx.prev_tx_id.append(change_endianness(parse_element(tx, 32)))
-                tx.prev_out_index.append(int(change_endianness(parse_element(tx, 4)), 16))
-                # ScriptSig
-                tx.scriptSig_len.append(int(parse_varint(tx), 16))
-                tx.scriptSig.append(parse_element(tx, tx.scriptSig_len[i]))
-                tx.nSequence.append(int(parse_element(tx, 4), 16))
-
-            # OUTPUTS
-            tx.outputs = int(parse_varint(tx), 16)
-
-            for i in range(tx.outputs):
-                tx.value.append(int(change_endianness(parse_element(tx, 8)), 16))
-                # ScriptPubKey
-                tx.scriptPubKey_len.append(int(parse_varint(tx), 16))
-                tx.scriptPubKey.append(parse_element(tx, tx.scriptPubKey_len[i]))
-
-            tx.nLockTime = int(parse_element(tx, 4), 16)
-
-            if tx.offset != len(tx.hex):
-                # There is some error in the serialized transaction passed as input. Transaction can't be built
-                tx = None
-            else:
-                tx.offset = 0
-
-        except ValueError:
-            # If a parsing error occurs, the deserialization stops and None is returned
-            tx = None
-
-        return tx
-
-    def serialize(self, rtype=hex):
-        """ Serialize all the transaction fields arranged in the proper order, resulting in a hexadecimal string
-        ready to be broadcast to the network.
-        :param self: self
-        :type self: TX
-        :param rtype: Whether the serialized transaction is returned as a hex str or a byte array.
-        :type rtype: hex or bool
-        :return: Serialized transaction representation (hexadecimal or bin depending on rtype parameter).
-        :rtype: hex str / bin
-        """
-
-        if rtype not in [hex, bin]:
-            raise Exception("Invalid return type (rtype). It should be either hex or bin.")
-        serialized_tx = change_endianness(int2bytes(self.version, 4))  # 4-byte version number (LE).
-
-        # INPUTS
-        serialized_tx += encode_varint(self.inputs)  # Varint number of inputs.
-
-        for i in range(self.inputs):
-            serialized_tx += change_endianness(self.prev_tx_id[i])  # 32-byte hash of the previous transaction (LE).
-            serialized_tx += change_endianness(int2bytes(self.prev_out_index[i], 4))  # 4-byte output index (LE)
-            serialized_tx += encode_varint(len(self.scriptSig[i]) // 2)  # Varint input script length.
-            # ScriptSig
-            serialized_tx += self.scriptSig[i]  # Input script.
-            serialized_tx += int2bytes(self.nSequence[i], 4)  # 4-byte sequence number.
-
-        # OUTPUTS
-        serialized_tx += encode_varint(self.outputs)  # Varint number of outputs.
-
-        if self.outputs != 0:
-            for i in range(self.outputs):
-                serialized_tx += change_endianness(int2bytes(self.value[i], 8))  # 8-byte field Satoshi value (LE)
-                # ScriptPubKey
-                serialized_tx += encode_varint(len(self.scriptPubKey[i]) // 2)  # Varint Output script length.
-                serialized_tx += self.scriptPubKey[i]  # Output script.
-
-        serialized_tx += int2bytes(self.nLockTime, 4)  # 4-byte lock time field
-
-        # If return type has been set to binary, the serialized transaction is converted.
-        if rtype is bin:
-            serialized_tx = unhexlify(serialized_tx)
-
-        return serialized_tx
-
-    @staticmethod
-    def create_dummy_transaction(prev_tx_id=None, prev_out_index=None):
-        tx = TX()
-
-        if prev_tx_id is None:
-            prev_tx_id = urandom(32).hex()
-
-        if prev_out_index is None:
-            prev_out_index = 0
-
-        tx.version = 1
-        tx.inputs = 1
-        tx.outputs = 1
-        tx.prev_tx_id = [prev_tx_id]
-        tx.prev_out_index = [prev_out_index]
-        tx.nLockTime = 0
-        tx.scriptSig = [
-            "47304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860"
-            "a4acdd12909d831cc56cbbac4622082221a8768d1d0901"
-        ]
-        tx.scriptSig_len = [77]
-        tx.nSequence = [4294967295]
-        tx.value = [5000000000]
-        tx.scriptPubKey = [
-            "4104ae1a62fe09c5f51b13905f07f06b99a2f7159b2225f374cd378d71302fa28414e7aab37397f554a7df5f142c21c"
-            "1b7303b8a0626f1baded5c72a704f7e6cd84cac"
-        ]
-        tx.scriptPubKey_len = [67]
-
-        return tx.serialize()
+    return tx.Tx.from_hex(dummy_hex)

--- a/bitcoind_mock/utils.py
+++ b/bitcoind_mock/utils.py
@@ -1,133 +1,17 @@
-# Porting some functionality from https://github.com/sr-gi/bitcoin_tools with some modifications <3
+import random
+
 from hashlib import sha256
 from binascii import unhexlify, hexlify
 
 
-def change_endianness(x):
-    """ Changes the endianness (from BE to LE and vice versa) of a given value.
-    :param x: Given value which endianness will be changed.
-    :type x: hex str
-    :return: The opposite endianness representation of the given value.
+def get_random_value_hex(nbytes):
+    """ Returns a pseduorandom hex value of a fixed length
+    :param nbytes: Integer number of random hex-encoded bytes to return
+    :type nbytes: int
+    :return: A pseduorandom hex string representing `nbytes` bytes
     :rtype: hex str
     """
+    pseudo_random_value = random.getrandbits(8 * nbytes)
 
-    # If there is an odd number of elements, we make it even by adding a 0
-    if (len(x) % 2) == 1:
-        x += "0"
-
-    y = unhexlify(x)
-    z = y[::-1]
-    return hexlify(z).decode("utf-8")
-
-
-def parse_varint(tx):
-    """ Parses a given transaction for extracting an encoded varint element.
-    :param tx: Transaction where the element will be extracted.
-    :type tx: TX
-    :return: The b-bytes representation of the given value (a) in hex format.
-    :rtype: hex str
-    """
-
-    # First of all, the offset of the hex transaction if moved to the proper position (i.e where the varint should be
-    #  located) and the length and format of the data to be analyzed is checked.
-    data = tx.hex[tx.offset :]
-    if len(data) > 0:
-        size = int(data[:2], 16)
-
-    else:
-        raise ValueError("No data to be parsed")
-
-    if size > 255:
-        raise ValueError("Wrong value (varint size > 255)")
-
-    # Then, the integer is encoded as a varint using the proper prefix, if needed.
-    if size <= 252:  # No prefix
-        storage_length = 1
-    elif size == 253:  # 0xFD
-        storage_length = 3
-    elif size == 254:  # 0xFE
-        storage_length = 5
-    elif size == 255:  # 0xFF
-        storage_length = 9
-    else:
-        raise Exception("Wrong input data size")
-
-    # Finally, the storage length is used to extract the proper number of bytes from the transaction hex and the
-    # transaction offset is updated.
-    varint = data[: storage_length * 2]
-    tx.offset += storage_length * 2
-
-    return varint
-
-
-def parse_element(tx, size):
-    """ Parses a given transaction to extract an element of a given size.
-    :param tx: Transaction where the element will be extracted.
-    :type tx: TX
-    :param size: Size of the parameter to be extracted.
-    :type size: int
-    :return: The extracted element.
-    :rtype: hex str
-    """
-
-    element = tx.hex[tx.offset : tx.offset + size * 2]
-    tx.offset += size * 2
-    return element
-
-
-def encode_varint(value):
-    """ Encodes a given integer value to a varint. It only used the four varint representation cases used by bitcoin:
-    1-byte, 2-byte, 4-byte or 8-byte integers.
-    :param value: The integer value that will be encoded into varint.
-    :type value: int
-    :return: The varint representation of the given integer value.
-    :rtype: str
-    """
-
-    # The value is checked in order to choose the size of its final representation.
-    # 0xFD(253), 0xFE(254) and 0xFF(255) are special cases, since are the prefixes defined for 2-byte, 4-byte
-    # and 8-byte long values respectively.
-    if value < pow(2, 8) - 3:
-        size = 1
-        varint = int2bytes(value, size)  # No prefix
-    else:
-        if value < pow(2, 16):
-            size = 2
-            prefix = 253  # 0xFD
-        elif value < pow(2, 32):
-            size = 4
-            prefix = 254  # 0xFE
-        elif value < pow(2, 64):
-            size = 8
-            prefix = 255  # 0xFF
-        else:
-            raise Exception("Wrong input data size")
-        varint = format(prefix, "x") + change_endianness(int2bytes(value, size))
-
-    return varint
-
-
-def int2bytes(a, b):
-    """ Converts a given integer value (a) its b-byte representation, in hex format.
-    :param a: Value to be converted.
-    :type a: int
-    :param b: Byte size to be filled.
-    :type b: int
-    :return: The b-bytes representation of the given value (a) in hex format.
-    :rtype: hex str
-    """
-
-    m = pow(2, 8 * b) - 1
-    if a > m:
-        raise Exception(
-            str(a) + " is too big to be represented with " + str(b) + " bytes. Maximum value is " + str(m) + "."
-        )
-
-    return ("%0" + str(2 * b) + "x") % a
-
-
-def sha256d(hex_data):
-    data = unhexlify(hex_data)
-    double_sha256 = sha256(sha256(data).digest()).hexdigest()
-
-    return change_endianness(double_sha256)
+    # left 0-pad, to 2*nbytes characters, lower-case hex
+    return f"{pseudo_random_value:0{2*nbytes}x}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ networkx
 flask
 requests
 pytest
+riemann-tx==2.1.0

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,17 +1,10 @@
 import pytest
-import random
 from time import sleep
 from threading import Thread
 
 import bitcoind_mock.conf as conf
 from bitcoind_mock.bitcoind import BitcoindMock
 from bitcoind_mock.auth_proxy import AuthServiceProxy
-
-
-def get_random_value_hex(nbytes):
-    pseudo_random_value = random.getrandbits(8 * nbytes)
-    prv_hex = "{:x}".format(pseudo_random_value)
-    return prv_hex.zfill(2 * nbytes)
 
 
 def bitcoin_cli():


### PR DESCRIPTION
Adds support for SegWit transactions. Adds a dependency on `riemann-tx`, which is dependency-free.

Consider adding some of the following to make development easier:
- flake8
- mypy
- unittest
- pipenv